### PR TITLE
Remove globstar from credits-npm

### DIFF
--- a/script/credits-npm
+++ b/script/credits-npm
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-shopt -s globstar
-
 DIR=$(cd $(dirname "$0"); pwd)
 ROOT=$(cd "$DIR/.."; pwd)
 cd "$ROOT"


### PR DESCRIPTION
The `globstar` option is the extension of Bash 4.0 so not available for many macOS users. I looked through the script but this can be removed.