### PR TITLE
Add an empty go file for go mod tidy

### DIFF
--- a/assets/keep.go
+++ b/assets/keep.go
@@ -1,0 +1,3 @@
+package assets
+
+// An empty file to make `go mod tidy` pass.


### PR DESCRIPTION
We encounter an issue that `go mod tidy` fails on empty package. Adding an empty file fixes the problem. Another solution is just including the generated file to the repository (this fixes the go get issue as well).