### PR TITLE
Clarify dependency on go-assets package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,6 @@ generate: deps
 
 .PHONY: clean
 clean:
-	rm -f assets/assets.go CREDITS.go.json CREDITS.npm.json
+	rm -f assets/assets.go assets.go CREDITS.go.json CREDITS.npm.json
 	rm -f $(BIN)
 	${GO} clean || true

--- a/assets/keep.go
+++ b/assets/keep.go
@@ -1,3 +1,5 @@
 package assets
 
 // An empty file to make `go mod tidy` pass.
+
+import _ "github.com/jessevdk/go-assets"


### PR DESCRIPTION
We don't include the generated files in repo so `go mod tidy` removes the dependency on go-assets. But Fireworqonsole executable actually depends on the package, so I added an import statement to keep the dependency in go.mod.