### PR TITLE
Add Dockerfile for production use

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+/.git/
+/.github/
+/dist/
+/node_modules/
+/vendoer/
+/assets/assets.go
+/assets/js/bundle.*
+
+/assets.go
+/AUTHORS
+/CREDITS
+/CREDITS.*.json
+
+/fireworqonsole
+
+mock_*.go

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-/.git/
 /.github/
 /dist/
 /node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.15 as builder
+ARG NODE_VERSION
+ENV PATH /xbuild/node-${NODE_VERSION}/bin:$PATH
+ENV APP_DIR /go/src/github.com/fireworq/fireworqonsole
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl jq \
+ && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/* \
+ && mkdir -p /usr/local /xbuild \
+ && git clone https://github.com/tagomoris/xbuild.git /usr/local/xbuild \
+ && /usr/local/xbuild/node-install v${NODE_VERSION} /xbuild/node-${NODE_VERSION}
+
+WORKDIR ${APP_DIR}
+COPY . .
+RUN make release PRERELEASE=
+
+FROM alpine:3.12.0
+ARG PORT=8888
+ENV FIREWORQONSOLE_BIND 0.0.0.0:$PORT
+ENV APP_DIR /go/src/github.com/fireworq/fireworqonsole
+
+COPY --from=builder ${APP_DIR}/fireworqonsole /usr/local/bin/
+EXPOSE $PORT
+ENTRYPOINT ["/usr/local/bin/fireworqonsole"]

--- a/main.go
+++ b/main.go
@@ -53,6 +53,12 @@ func main() {
 	flags.Var(&nodes, "node", "")
 	flags.StringVar(&bind, "bind", "127.0.0.1:8888", "")
 	flags.UintVar(&shutdownTimeout, "shutdown-timeout", 30, "")
+	flags.VisitAll(func(f *flag.Flag) {
+		env := "FIREWORQONSOLE_" + strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_")
+		if s := os.Getenv(env); s != "" {
+			f.Value.Set(s)
+		}
+	})
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
# What
- I added new Dockerfile for production use.
- Generates a smaller image than the existing one, containing only a minimal amount of resources.
- All CLI option's default value can be set by environment variable now.

# Why
- I plan to publish the official image to Docker Hub like fireworq itself.
  - https://hub.docker.com/r/fireworq/fireworq/
- I will change documentation when publish official image.

# How to use

```shell
$ docker build --force-rm=true --build-arg NODE_VERSION=$(cat .node-version) -t fireworqonsole .
$ docker run --rm -e FIREWORQONSOLE_NODE=<NODE_URL> -p 8888:8888 --name fireworqonsole fireworqonsole
```