### PR TITLE
Added action to push image to DockerHub

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Release Docker Image
+name: Publish Docker Image
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  release:
+  publish:
     runs-on: ubuntu-18.04
     steps:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,4 +29,4 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: fireworq/fireworqonsole
         tags: latest, ${{ steps.variables.outputs.release_tag_patch }}, ${{ steps.variables.outputs.release_tag_minor }}
-        build_args: NODE_VERSION=${{ steps.variables.node_version }}
+        build_args: NODE_VERSION=${{ steps.variables.outputs.node_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release Docker Image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set variables
+      id: variables
+      run: |
+        git_tag_name="${{ github.event.release.tag_name }}"
+        git_tag_name="${git_tag_name#v}"
+        echo "::set-output name=release_tag_patch::${git_tag_name}"
+        echo "::set-output name=release_tag_minor::${git_tag_name%.*}"
+        echo "::set-output name=node_version::$(cat .node-version)"
+
+    - name: Build and Release
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        repository: fireworq/fireworqonsole
+        tags: latest, ${{ steps.variables.outputs.release_tag_patch }}, ${{ steps.variables.outputs.release_tag_minor }}
+        build_args: NODE_VERSION=${{ steps.variables.node_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: docker/build-push-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: fireworq/fireworqonsole
         tags: latest, ${{ steps.variables.outputs.release_tag_patch }}, ${{ steps.variables.outputs.release_tag_minor }}
         build_args: NODE_VERSION=${{ steps.variables.node_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,23 +10,23 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Set variables
-      id: variables
-      run: |
-        git_tag_name="${{ github.event.release.tag_name }}"
-        git_tag_name="${git_tag_name#v}"
-        echo "::set-output name=release_tag_patch::${git_tag_name}"
-        echo "::set-output name=release_tag_minor::${git_tag_name%.*}"
-        echo "::set-output name=node_version::$(cat .node-version)"
+      - name: Set variables
+        id: variables
+        run: |
+          git_tag_name="${{ github.event.release.tag_name }}"
+          git_tag_name="${git_tag_name#v}"
+          echo "::set-output name=release_tag_patch::${git_tag_name}"
+          echo "::set-output name=release_tag_minor::${git_tag_name%.*}"
+          echo "::set-output name=node_version::$(cat .node-version)"
 
-    - name: Build and Release
-      uses: docker/build-push-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        repository: fireworq/fireworqonsole
-        tags: latest, ${{ steps.variables.outputs.release_tag_patch }}, ${{ steps.variables.outputs.release_tag_minor }}
-        build_args: NODE_VERSION=${{ steps.variables.outputs.node_version }}
+      - name: Build and Release
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: fireworq/fireworqonsole
+          tags: latest, ${{ steps.variables.outputs.release_tag_patch }}, ${{ steps.variables.outputs.release_tag_minor }}
+          build_args: NODE_VERSION=${{ steps.variables.outputs.node_version }}


### PR DESCRIPTION
# What
- Build production docker image and push it to DockerHub using GitHub Actions.

# Required
- Set `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` to organization secrets.
  - I plan to change [fireworq's secret](https://github.com/fireworq/fireworq/blob/cdef9a715f639123595d828f0a7230a5acdfffd5/.github/workflows/release.yaml#L27-L28) from repository secrets to organization one.
