### PR TITLE
print NODE_VERSION is required on building the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.15 as builder
 ARG NODE_VERSION
+RUN : ${NODE_VERSION:?NODE_VERSION is required}
 ENV PATH /xbuild/node-${NODE_VERSION}/bin:$PATH
 ENV APP_DIR /go/src/github.com/fireworq/fireworqonsole
 


### PR DESCRIPTION
I feel it hard to tell what's wrong when I run `docker build -t fireworqonsole .`.

```
#7 3.829 Cloning into '/usr/local/xbuild'...
#7 5.595 
#7 5.595 gzip: stdin: not in gzip format
#7 5.595 tar: Child returned status 1
#7 5.595 tar: Error is not recoverable: exiting now
------
executor failed running [/bin/sh -c apt-get update && apt-get install -y --no-install-recommends curl jq  && apt-get clean && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*  && mkdir -p /usr/
local /xbuild  && git clone https://github.com/tagomoris/xbuild.git /usr/local/xbuild  && /usr/local/xbuild/node-install v${NODE_VERSION} /xbuild/node-${NODE_VERSION}]: exit code: 2
```

Checking the arg fails with
```
 => ERROR [builder 2/6] RUN : ${NODE_VERSION:?NODE_VERSION is required}                                                                                                                          0.3s
------
 > [builder 2/6] RUN : ${NODE_VERSION:?NODE_VERSION is required}:
#7 0.241 /bin/sh: 1: NODE_VERSION: NODE_VERSION is required
```