### PR TITLE
Update Renovate schedule for Golang package golang.org/x/net

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
     {
       "updateTypes": ["patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "datasources": ["go"],
+      "packageNames": ["golang.org/x/net"],
+      "extends": ["schedule:quarterly"]
     }
   ]
 }


### PR DESCRIPTION
Recently [golang.org/x/net](https://github.com/golang/net) is updated frequently and I believe the package is less likely to be broken, I think we can change the schedule to see less Renovate updates.