### PR TITLE
Remove vendoer from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 /.github/
 /dist/
 /node_modules/
-/vendoer/
 /assets/css/loaders.min.css
 /assets/js/bundle.*
 


### PR DESCRIPTION
This is a misconfiguration of /vendor/, and unnecessary after Go-mod. migration anyway.