### PR TITLE
Add queue throttle management

### DIFF
--- a/assets/css/common.css
+++ b/assets/css/common.css
@@ -519,7 +519,7 @@ dl.settings .setting-diff .setting-value {
   color: #555555;
   float: left;
   clear: both;
-  width: 8em;
+  width: 14em;
 }
 
 .queue-list .queue dl.config dd {

--- a/client/queue-list/QueueList.tsx
+++ b/client/queue-list/QueueList.tsx
@@ -94,11 +94,26 @@ export class QueueList extends React.Component<Props, {}> {
           </div>
 
           <Link to={pathQueueEdit(queue.name)}><dl className="config">
-            <dt>polling interval</dt>
-            <dd>{queue.pollingInterval} {typeof queue.pollingInterval === 'number' ? 'ms' : null}</dd>
+            {!queue.maxDispatchesPerSecond ? (
+              <>
+                <dt>polling interval</dt>
+                <dd>{queue.pollingInterval} {typeof queue.pollingInterval === 'number' ? 'ms' : null}</dd>
+              </>
+            ) : null}
 
             <dt>workers</dt>
             <dd><span title="running">{runningWorkers}</span> / <span title="total">{totalWorkers}</span></dd>
+
+            {queue.maxDispatchesPerSecond ? (
+              <>
+                <dt>max dispatches per second</dt>
+                <dd>{queue.maxDispatchesPerSecond}</dd>
+
+                <dt>max burst size</dt>
+                <dd>{queue.maxBurstSize}</dd>
+              </>
+            ) : null}
+
           </dl></Link>
 
           {chart}

--- a/client/queue/Queue.tsx
+++ b/client/queue/Queue.tsx
@@ -80,23 +80,37 @@ export class Queue extends React.Component<Props, {}> {
             }
           </dd>
 
-          <dt>Max Dispatches Per Second</dt>
-          <dd className="config-value">
-            {this.props.editing ?
-               <input name="max-dispatches-per-second" defaultValue={maxDispatchesPerSecond} placeholder="1.0" />
-            :
-               <Link to={pathQueueEdit(queueName)}>{queue.maxDispatchesPerSecond}</Link>
-            }
-          </dd>
+          {this.props.editing ?
+            <>
+              <dt>Max Dispatches Per Second</dt>
+              <dd className="config-value">
+                <input name="max-dispatches-per-second" defaultValue={maxDispatchesPerSecond} placeholder="1.0" />
+              </dd>
+            </>
+          : queue.maxDispatchesPerSecond ?
+            <>
+              <dt>Max Dispatches Per Second</dt>
+              <dd className="config-value">
+                <Link to={pathQueueEdit(queueName)}>{queue.maxDispatchesPerSecond}</Link>
+              </dd>
+            </>
+          : null}
 
-          <dt>Max Burst Size</dt>
-          <dd className="config-value">
-            {this.props.editing ?
-               <input name="max-burst-size" defaultValue={maxBurstSize} placeholder="5" />
-            :
-               <Link to={pathQueueEdit(queueName)}>{queue.maxBurstSize}</Link>
-            }
-          </dd>
+          {this.props.editing ?
+            <>
+              <dt>Max Burst Size</dt>
+              <dd className="config-value">
+                <input name="max-burst-size" defaultValue={maxBurstSize} placeholder="5" />
+              </dd>
+            </>
+          : queue.maxBurstSize ?
+            <>
+              <dt>Max Burst Size</dt>
+              <dd className="config-value">
+                <Link to={pathQueueEdit(queueName)}>{queue.maxBurstSize}</Link>
+              </dd>
+            </>
+          : null}
 
           <dt>Stats</dt>
           <dd className="stats chart"><Stats queueName={queueName} autoReload={true} /></dd>

--- a/client/queue/Queue.tsx
+++ b/client/queue/Queue.tsx
@@ -42,6 +42,10 @@ export class Queue extends React.Component<Props, {}> {
       queue.pollingInterval ? queue.pollingInterval + '' : '';
     const maxWorkersValue =
       queue.maxWorkers ? queue.maxWorkers + '' : '';
+    const maxDispatchesPerSecond =
+      queue.maxDispatchesPerSecond ? queue.maxDispatchesPerSecond + '' : '';
+    const maxBurstSize =
+      queue.maxBurstSize ? queue.maxBurstSize + '' : '';
 
     const deleteQueue = (e: React.SyntheticEvent<any>) => {
       if (confirm("Are you sure you want to delete queue '" + queueName + "'?\n\nNote that all routings related to the queue are also deleted."))
@@ -73,6 +77,24 @@ export class Queue extends React.Component<Props, {}> {
                <input name="max-workers" defaultValue={maxWorkersValue} placeholder="20" />
             :
                <Link to={pathQueueEdit(queueName)}>{queue.maxWorkers}</Link>
+            }
+          </dd>
+
+          <dt>Max Dispatches Per Second</dt>
+          <dd className="config-value">
+            {this.props.editing ?
+               <input name="max-dispatches-per-second" defaultValue={maxDispatchesPerSecond} placeholder="1.0" />
+            :
+               <Link to={pathQueueEdit(queueName)}>{queue.maxDispatchesPerSecond}</Link>
+            }
+          </dd>
+
+          <dt>Max Burst Size</dt>
+          <dd className="config-value">
+            {this.props.editing ?
+               <input name="max-burst-size" defaultValue={maxBurstSize} placeholder="5" />
+            :
+               <Link to={pathQueueEdit(queueName)}>{queue.maxBurstSize}</Link>
             }
           </dd>
 
@@ -108,9 +130,14 @@ export class Queue extends React.Component<Props, {}> {
                if (this.props.value.savingCount !== 0) return;
 
                const formData = new FormData(e.target as HTMLFormElement);
+               const mdps = formData.get('max-dispatches-per-second');
+               const maxBurstSize = formData.get('max-burst-size')
+
                this.props.actions.asyncPutQueue(queueName, {
                  polling_interval: parseInt(formData.get('polling-interval') as string || '', 10),
-                 max_workers: parseInt(formData.get('max-workers') as string || '', 10)
+                 max_workers: parseInt(formData.get('max-workers') as string || '', 10),
+                 max_dispatches_per_second: mdps ? parseFloat(mdps as string) : undefined,
+                 max_burst_size: maxBurstSize ? parseInt(maxBurstSize as string, 10) : undefined,
                });
            }}>
              {queueInfo}

--- a/client/queue/module.ts
+++ b/client/queue/module.ts
@@ -127,6 +127,8 @@ export interface Queue {
   name: string
   pollingInterval: number | string
   maxWorkers: number
+  maxDispatchesPerSecond?: number
+  maxBurstSize?: number
 };
 
 export interface QueueState {


### PR DESCRIPTION
Related issue: https://github.com/fireworq/fireworq/pull/144

This p-r copes with new feature of fireworq, queue throttle. 

Queue listing is extended as follows. Meaningless fields are dropped.

<img width="1217" alt="スクリーンショット 2021-06-28 17 54 52" src="https://user-images.githubusercontent.com/7097192/123612146-42305300-d83d-11eb-9766-f7242ae1c8b2.png">

Queue page is extended as follows. All fields are displayed and can be edited. I think more complex control over fields is overkill.

<img width="418" alt="スクリーンショット 2021-06-28 18 20 21" src="https://user-images.githubusercontent.com/7097192/123613135-24afb900-d83e-11eb-8fab-5ae74f16a4aa.png">
<img width="429" alt="スクリーンショット 2021-06-28 18 20 30" src="https://user-images.githubusercontent.com/7097192/123613168-2b3e3080-d83e-11eb-9342-39a606d6e241.png">
