### PR TITLE
Add button role to New spans

### DIFF
--- a/client/queue-list/QueueList.tsx
+++ b/client/queue-list/QueueList.tsx
@@ -124,7 +124,7 @@ export class QueueList extends React.Component<Props, {}> {
             e.stopPropagation()
             e.preventDefault()
         }}>
-          <label><span className="label-text">New</span>
+          <label><span className="label-text" role="button">New</span>
             <input className="new-queue-name" name="queue-name" defaultValue="" placeholder=" queue name" />
             <button type="submit">Add</button>
           </label>

--- a/client/routing-list/RoutingList.tsx
+++ b/client/routing-list/RoutingList.tsx
@@ -71,7 +71,7 @@ export class RoutingList extends React.Component<Props, {}> {
             e.stopPropagation()
             e.preventDefault()
         }}>
-          <label><span className="label-text">New</span>
+          <label><span className="label-text" role="button">New</span>
             <input className="new-job-category" name="job-category" defaultValue="" placeholder=" job category" />
             <button type="submit">Add</button>
           </label>

--- a/client/version-list/VersionList.tsx
+++ b/client/version-list/VersionList.tsx
@@ -76,7 +76,7 @@ export class VersionList extends React.Component<Props, {}> {
                e.stopPropagation()
                e.preventDefault()
            }}>
-             <label><span className="label-text">New</span>
+             <label><span className="label-text" role="button">New</span>
                <input className="new-node-url" name="node-url" defaultValue="" placeholder=" http://localhost:8080" />
                <button type="submit">Add</button>
              </label>


### PR DESCRIPTION
This improves accessibility by adding button role to the +New buttons. This is important hint for browser extensions to find clickable elements. BTW the current DOM structure looks a little bit wired; input element inside label element, but styles rely on this so I'll leave it as it is.